### PR TITLE
docker: Update rust version used to compile

### DIFF
--- a/dockerized/Dockerfile
+++ b/dockerized/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust:1.69.0 AS chef
+FROM --platform=linux/amd64 rust:1.77.2-bullseye AS chef
 ARG RELEASE_TAG
 WORKDIR /ebu
 RUN apt-get update && apt-get install -y git cmake clang pkg-config libssl-dev build-essential


### PR DESCRIPTION
Fixes incompatibility with jsonwebtoken dependency and ensures the same Debian base version is used to compile and run to avoid libssl.so.3 not found errors.

Previously building docker image failed with:
```
79.69 error: failed to compile `executionbackup v1.1.2 (/ebu)`, intermediate artifacts can be found at `/ebu/target`
79.69
79.69 Caused by:
79.69   package `jsonwebtoken v9.3.0` cannot be built because it requires rustc 1.73.0 or newer, while the currently active rustc version is 1.69.0
79.69   Either upgrade to rustc 1.73.0 or newer, or use
79.69   cargo update -p jsonwebtoken@9.3.0 --precise ver
79.69   where `ver` is the latest version of `jsonwebtoken` supporting rustc 1.69.0
```